### PR TITLE
Fix issue #20: drop packages

### DIFF
--- a/poetry_lock_package/app.py
+++ b/poetry_lock_package/app.py
@@ -217,7 +217,8 @@ def run(
     project["tool"]["poetry"]["dependencies"] = dependencies
 
     del_keys(
-        project["tool"]["poetry"], ["scripts", "readme", "include", "extras", "plugins"]
+        project["tool"]["poetry"],
+        ["scripts", "readme", "include", "extras", "plugins", "packages"],
     )
 
     lock_project_path = create_or_update(project, should_create_tests)


### PR DESCRIPTION
When using the root project as a template, drop the package
entry to make sure we don't use that.