### PR TITLE
add option --ignore-editable to ignore editable dependencies

### DIFF
--- a/poetry_lock_package/app.py
+++ b/poetry_lock_package/app.py
@@ -21,9 +21,10 @@ MAX_RECURSION_DEPTH = 1000
 
 
 def collect_dependencies(
-    lock_toml, package_names: List[str],
+    lock_toml,
+    package_names: List[str],
     allow_package_filter: Callable[[str], bool],
-    ignore_editable_dependencies: bool
+    ignore_editable_dependencies: bool,
 ) -> Dict[str, Any]:
     def read_lock_information(name: str):
         """select lock information for given dependency"""
@@ -36,8 +37,10 @@ def collect_dependencies(
 
     def editable_filter(name: str):
         for locked_package in lock_toml["package"]:
-            if locked_package['name'] == name and \
-                    locked_package.get('source', {}).get('type') == 'directory':
+            if (
+                locked_package["name"] == name
+                and locked_package.get("source", {}).get("type") == "directory"
+            ):
                 print(locked_package)
                 return False
         return True
@@ -45,8 +48,8 @@ def collect_dependencies(
     collected = {
         name: read_lock_information(name)
         for name in package_names
-        if allow_package_filter(name) and (not ignore_editable_dependencies
-                                           or editable_filter(name))
+        if allow_package_filter(name)
+        and (not ignore_editable_dependencies or editable_filter(name))
     }
     del package_names
 
@@ -157,7 +160,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--ignore-editable",
         help="Do not add editable dependencies as a dependency of lock package.",
-        action="store_true"
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -213,14 +216,16 @@ def run(
     clean_up_project: bool,
     allow_package_filter: Callable[[str], bool],
     add_root: bool,
-    ignore_editable_dependencies: bool
+    ignore_editable_dependencies: bool,
 ) -> None:
     project = read_toml("pyproject.toml")
     lock = read_toml("poetry.lock")
 
     root_dependencies = project_root_dependencies(project)
     dependencies = clean_dependencies(
-        collect_dependencies(lock, root_dependencies, allow_package_filter, ignore_editable_dependencies)
+        collect_dependencies(
+            lock, root_dependencies, allow_package_filter, ignore_editable_dependencies
+        )
     )
     dependencies["python"] = project["tool"]["poetry"]["dependencies"]["python"]
     if add_root:

--- a/poetry_lock_package/app.py
+++ b/poetry_lock_package/app.py
@@ -41,7 +41,6 @@ def collect_dependencies(
                 locked_package["name"] == name
                 and locked_package.get("source", {}).get("type") == "directory"
             ):
-                print(locked_package)
                 return False
         return True
 

--- a/tests/resources/editable_dependency.lock
+++ b/tests/resources/editable_dependency.lock
@@ -1,0 +1,20 @@
+[[package]]
+name = "my_editable_package"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "^3.7"
+develop = true
+
+[package.source]
+type = "directory"
+url = "../../libs/my_editable_package"
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,7 +28,7 @@ def test_main():
         clean_up_project=True,
         allow_package_filter=lambda _: True,
         add_root=True,
-        ignore_editable_dependencies=False
+        ignore_editable_dependencies=False,
     )
     assert not os.path.exists(
         "poetry-lock-package-lock"
@@ -65,12 +65,17 @@ def test_collect_dependencies():
 def test_collect_dependencies_ignore_editable():
     with open("tests/resources/editable_dependency.lock", "r") as lock_file:
         lock_toml = toml.load(lock_file)
-    assert clean_dependencies(
-        collect_dependencies(lock_toml, ["my_editable_package"], always(True), True)
-    ) == {}
+    assert (
+        clean_dependencies(
+            collect_dependencies(lock_toml, ["my_editable_package"], always(True), True)
+        )
+        == {}
+    )
 
     assert clean_dependencies(
-        collect_dependencies(lock_toml, ["my_editable_package", "atomicwrites"], always(True), True)
+        collect_dependencies(
+            lock_toml, ["my_editable_package", "atomicwrites"], always(True), True
+        )
     ) == {
         "atomicwrites": {
             "python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",


### PR DESCRIPTION
Pip raise invalid url for dependencies that are editable:

[tool.poetry.dependencies]
my-package = {path = "../my/path", develop = true}

Pip:
pip._vendor.pkg_resources.RequirementParseError: Invalid URL: ../my/path

The option --ignore-editable search the .lock file for 
[package.source]
type = "directory"

and ignore the dependency on project_lock if type == "directory"