### PR TITLE
Fix the help message for --ignore argument

### DIFF
--- a/poetry_lock_package/app.py
+++ b/poetry_lock_package/app.py
@@ -142,7 +142,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--ignore",
         metavar="REGEX",
-        help="Do not add the root/parent project as a dependency of lock package.",
+        help="Omit the specified dependencies from the lock package.",
         action="append",
         default=[],
     )


### PR DESCRIPTION
The help annotation for `--ignore` appears to have been copied from `--no-root` but not updated.

To see the problem, look at the duplication in the last two lines.

```
$ poetry-lock-package --help
usage: poetry-lock-package [-h] [--tests] [--wheel] [--move] [--clean] [--build] [--no-root] [--ignore REGEX]

Generate a lock package Poetry project this parent Poetry project.

optional arguments:
  -h, --help      show this help message and exit
  --tests         Create a mock tests folder in the lock project or not.
  --wheel         Execute poetry build wheel inside lock project.
  --move          Move poetry lock package dist/ files to local dist folder.
  --clean         Remove lock project afterwards.
  --build         Alias for --wheel --move --clean.
  --no-root       Do not add the root/parent project as a dependency of lock package.
  --ignore REGEX  Do not add the root/parent project as a dependency of lock package.
```