### PR TITLE
Add [build-system] section to lock's pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
       - id: black

--- a/poetry_lock_package/app.py
+++ b/poetry_lock_package/app.py
@@ -232,7 +232,11 @@ def run(
                 "maintainers": parent_project["tool"]["poetry"].get("maintainers"),
                 "repository": parent_project["tool"]["poetry"].get("repository"),
             }
-        }
+        },
+        "build-system": {
+            "requires": ["poetry-core>=1.0.8"],
+            "build-backend": "poetry.core.masonry.api",
+        },
     }
 
     lock_project_path = create_or_update(lock_project, should_create_tests)


### PR DESCRIPTION
This allows for the possibility to simply `pip install ./project_name_lock` without having to install poetry.

This is very helpful for containerization.