### PR TITLE
Add explicit file encoding argument to open statements

### DIFF
--- a/poetry_lock_package/app.py
+++ b/poetry_lock_package/app.py
@@ -288,7 +288,7 @@ def create_or_update(project: Dict[str, Any], should_create_tests: bool) -> str:
 
     # Create project toml
     with open(
-        os.path.join(lock_project_path, "pyproject.toml"), "w"
+        os.path.join(lock_project_path, "pyproject.toml"), "w", encoding="utf-8"
     ) as requirements_toml:
         toml.dump(project, requirements_toml)
     return lock_project_path

--- a/poetry_lock_package/util.py
+++ b/poetry_lock_package/util.py
@@ -33,14 +33,14 @@ def del_keys(dictionary: Dict[Any, Any], keys: List[str]) -> None:
 
 
 def read_toml(filename: str) -> MutableMapping[str, Any]:
-    with open(filename, "r") as project_file:
+    with open(filename, "r", encoding="utf-8") as project_file:
         return toml.load(project_file)
 
 
 def create_and_write(path: str, contents: str) -> None:
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w") as output_file:
+        with open(path, "w", encoding="utf-8") as output_file:
             output_file.write(contents)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,7 +41,7 @@ def test_lock_package_name():
 
 
 def test_collect_dependencies():
-    with open("tests/resources/example1.lock", "r") as lock_file:
+    with open("tests/resources/example1.lock", "r", encoding="utf-8") as lock_file:
         lock_toml = toml.load(lock_file)
         assert clean_dependencies(
             collect_dependencies(lock_toml, ["atomicwrites"], always(True))
@@ -62,7 +62,7 @@ def test_collect_dependencies():
 
 
 def test_lock_file_v2() -> None:
-    with open("tests/resources/poetry_v2.lock", "r") as lock_file:
+    with open("tests/resources/poetry_v2.lock", "r", encoding="utf-8") as lock_file:
         lock_toml = toml.load(lock_file)
         assert clean_dependencies(
             collect_dependencies(lock_toml, ["arrow"], always(True))
@@ -116,7 +116,7 @@ def test_clean_dependencies_should_ignore_extra_via_dependency():
 
 def test_issue_36_lock() -> None:
     """If the dependency information contains more markers for different versions, we incorrectly merge the configuration"""
-    with open("tests/resources/issue_36.lock", "r") as lock_file:
+    with open("tests/resources/issue_36.lock", "r", encoding="utf-8") as lock_file:
         lock_toml = toml.load(lock_file)
         collected_deps = collect_dependencies(
             lock_toml, ["aioboto3", "docker", "requests"], always(True)


### PR DESCRIPTION
I don't have a windows machine to test this atm, but I think this might solve the issue for windows users.

Closes #35 